### PR TITLE
feat: Add functionality to copy teams to clipboard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1774,6 +1774,35 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@fortawesome/angular-fontawesome": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/angular-fontawesome/-/angular-fontawesome-0.7.0.tgz",
+      "integrity": "sha512-U+eHYbKuVYrrm9SnIfl+z+6KTiI4Pu+S2OKh34JIi7C1jHhDcrVeDZISP/cpswHY7LWWDOPYeKE+yuWFlL4aVw==",
+      "requires": {
+        "tslib": "^2.0.0"
+      }
+    },
+    "@fortawesome/fontawesome-common-types": {
+      "version": "0.2.35",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.35.tgz",
+      "integrity": "sha512-IHUfxSEDS9dDGqYwIW7wTN6tn/O8E0n5PcAHz9cAaBoZw6UpG20IG/YM3NNLaGPwPqgjBAFjIURzqoQs3rrtuw=="
+    },
+    "@fortawesome/fontawesome-svg-core": {
+      "version": "1.2.35",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.35.tgz",
+      "integrity": "sha512-uLEXifXIL7hnh2sNZQrIJWNol7cTVIzwI+4qcBIq9QWaZqUblm0IDrtSqbNg+3SQf8SMGHkiSigD++rHmCHjBg==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "^0.2.35"
+      }
+    },
+    "@fortawesome/free-solid-svg-icons": {
+      "version": "5.15.3",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.15.3.tgz",
+      "integrity": "sha512-XPeeu1IlGYqz4VWGRAT5ukNMd4VHUEEJ7ysZ7pSSgaEtNvSo+FLurybGJVmiqkQdK50OkSja2bfZXOeyMGRD8Q==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "^0.2.35"
+      }
+    },
     "@istanbuljs/schema": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,9 @@
         "@angular/platform-browser": "~10.1.1",
         "@angular/platform-browser-dynamic": "~10.1.1",
         "@angular/router": "~10.1.1",
+        "@fortawesome/angular-fontawesome": "^0.7.0",
+        "@fortawesome/fontawesome-svg-core": "^1.2.28",
+        "@fortawesome/free-solid-svg-icons": "^5.13.0",
         "rxjs": "~6.6.3",
         "tslib": "^2.0.0",
         "zone.js": "~0.10.2"

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -3,6 +3,7 @@ import { TestBed, waitForAsync } from '@angular/core/testing';
 import { ReactiveFormsModule, FormsModule } from '@angular/forms';
 import { BrowserModule } from '@angular/platform-browser';
 import { RouterTestingModule } from '@angular/router/testing';
+import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 import { AppComponent } from './app.component';
 import { TeamGeneratorComponent } from './team-generator/team-generator.component';
 
@@ -16,6 +17,7 @@ describe('AppComponent', () => {
                     FormsModule,
                     HttpClientModule,
                     ReactiveFormsModule,
+                    FontAwesomeModule,
                 ],
                 declarations: [AppComponent, TeamGeneratorComponent],
             }).compileComponents();

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -2,6 +2,7 @@ import { HttpClientModule } from '@angular/common/http';
 import { NgModule } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { BrowserModule } from '@angular/platform-browser';
+import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
 import { TeamGeneratorComponent } from './team-generator/team-generator.component';
@@ -14,6 +15,7 @@ import { TeamGeneratorComponent } from './team-generator/team-generator.componen
         FormsModule,
         HttpClientModule,
         ReactiveFormsModule,
+        FontAwesomeModule,
     ],
     providers: [],
     bootstrap: [AppComponent],

--- a/src/app/team-generator/team-generator.component.css
+++ b/src/app/team-generator/team-generator.component.css
@@ -1,0 +1,3 @@
+.team__captain--bold {
+  font-weight: bold;
+}

--- a/src/app/team-generator/team-generator.component.html
+++ b/src/app/team-generator/team-generator.component.html
@@ -77,20 +77,20 @@
             >
         </div>
 
-        <div class="card-deck">
+        <div class="card-deck js-teams team">
             <div
                 *ngFor="let team of randomTeams.teams; let i = index"
                 [attr.data-index]="i"
             >
                 <div class="card m-2">
-                    <div class="card-header text-white bg-info">
+                    <div class="card-header text-white bg-info" contenteditable="true">
                         Team {{ i + 1 }}
                     </div>
                     <ul class="list-group list-group-flush">
                         <li
                             *ngFor="let member of team.members"
                             [ngClass]="{
-                                'list-group-item-warning':
+                                'list-group-item-warning team__captain--bold':
                                     member.isCaptain && showCaptain.checked
                             }"
                             class="list-group-item"
@@ -101,5 +101,14 @@
                 </div>
             </div>
         </div>
+
+        <button
+            *ngIf="randomTeams.teams.length > 0"
+            type="button"
+            class="btn btn-info js-copy-button"
+            (click)="copyTeamsToClipboard()"
+        >
+            <fa-icon [icon]="faCopy"></fa-icon> Copy
+        </button>
     </div>
 </div>

--- a/src/app/team-generator/team-generator.component.spec.ts
+++ b/src/app/team-generator/team-generator.component.spec.ts
@@ -7,6 +7,7 @@ import {
     waitForAsync,
 } from '@angular/core/testing';
 import { ReactiveFormsModule, FormsModule } from '@angular/forms';
+import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 import { Observable, of } from 'rxjs';
 import { TeamGeneratorComponent } from './team-generator.component';
 import { TeamGeneratorService } from './team-generator.service';
@@ -31,6 +32,26 @@ class MockTeamGeneratorService {
 }
 
 describe('TeamGeneratorComponent', () => {
+    const pascal = 'Pascal';
+    const gullivar = 'Gullivar';
+    const gullivarr = 'Gullivarr';
+    const blathers = 'Blathers';
+
+    const mockPlayers: Players = new Players();
+    mockPlayers.setNames([pascal, gullivar, gullivarr, blathers]);
+
+    const mockTeam1: Players = new Players();
+    mockTeam1.setNames([pascal, gullivarr]);
+    mockTeam1.members[1].isCaptain = true;
+
+    const mockTeam2: Players = new Players();
+    mockTeam2.setNames([blathers, gullivar]);
+    mockTeam2.members[0].isCaptain = true;
+
+    const mockTeams: Teams = {
+        teams: [mockTeam1, mockTeam2],
+    };
+
     let component: TeamGeneratorComponent;
     let teamGeneratorService: TeamGeneratorService;
     let fixture: ComponentFixture<TeamGeneratorComponent>;
@@ -38,7 +59,7 @@ describe('TeamGeneratorComponent', () => {
     beforeEach(
         waitForAsync(() => {
             TestBed.configureTestingModule({
-                imports: [ReactiveFormsModule, HttpClientModule, FormsModule],
+                imports: [ReactiveFormsModule, HttpClientModule, FormsModule, FontAwesomeModule],
                 declarations: [TeamGeneratorComponent],
                 providers: [
                     {
@@ -109,26 +130,6 @@ describe('TeamGeneratorComponent', () => {
         const ERROR_MESSAGE = 'Enter players!';
 
         it('should generate teams', fakeAsync(() => {
-            const pascal = 'Pascal';
-            const gullivar = 'Gullivar';
-            const gullivarr = 'Gullivarr';
-            const blathers = 'Blathers';
-
-            const mockPlayers: Players = new Players();
-            mockPlayers.setNames([pascal, gullivar, gullivarr, blathers]);
-
-            const mockTeam1: Players = new Players();
-            mockTeam1.setNames([pascal, gullivarr]);
-            mockTeam1.members[1].isCaptain = true;
-
-            const mockTeam2: Players = new Players();
-            mockTeam2.setNames([blathers, gullivar]);
-            mockTeam2.members[0].isCaptain = true;
-
-            const mockTeams: Teams = {
-                teams: [mockTeam1, mockTeam2],
-            };
-
             const spy = spyOn(
                 teamGeneratorService,
                 'generateTeams'
@@ -244,6 +245,38 @@ describe('TeamGeneratorComponent', () => {
             expect(
                 component.playersForm.value.names.replace(/\s+/g, '')
             ).toEqual('abc');
+        }));
+    });
+
+    describe('copyTeamsToClipboard', () => {
+        it('should not show copy button when no teams', () => {
+            fixture.detectChanges();
+            const compiled: HTMLElement = fixture.debugElement.nativeElement;
+            const copyButton = compiled.querySelector('.js-copy-button');
+            expect(copyButton).toBeNull();
+        });
+
+        it('should copy teams to clipboard', fakeAsync(() => {
+            fixture.detectChanges();
+            spyOn(document, 'execCommand');
+            spyOn(
+                teamGeneratorService,
+                'generateTeams'
+            ).and.returnValue(mockTeams);
+
+            component.onSubmit({
+                names: `${pascal} \r\n ${gullivar} \r\n ${gullivarr} \r\n ${blathers}`,
+                numTeams: '2',
+            });
+            fixture.detectChanges();
+
+            const compiled: HTMLElement = fixture.debugElement.nativeElement;
+            const copyButton: HTMLElement = compiled.querySelector('.js-copy-button');
+            expect(copyButton).not.toBeNull();
+
+            copyButton.click();
+            fixture.detectChanges();
+            expect(document.execCommand).toHaveBeenCalledWith('copy');
         }));
     });
 });

--- a/src/app/team-generator/team-generator.component.ts
+++ b/src/app/team-generator/team-generator.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { FormBuilder, FormGroup } from '@angular/forms';
+import { faCopy } from '@fortawesome/free-solid-svg-icons';
 import { TeamGeneratorService } from './team-generator.service';
 import { Teams } from '../model/teams';
 import { Players } from '../model/players';
@@ -10,6 +11,7 @@ import { Players } from '../model/players';
     styleUrls: ['./team-generator.component.css'],
 })
 export class TeamGeneratorComponent implements OnInit {
+    public faCopy = faCopy;
     public playersForm: FormGroup;
     public randomTeams: Teams;
     public playersSubmitted = true;
@@ -85,5 +87,19 @@ export class TeamGeneratorComponent implements OnInit {
                 numTeams: this.defaultNumTeams,
             });
         });
+    }
+
+    /**
+     * Copy teams list for pasting
+     */
+    copyTeamsToClipboard() {
+      const teamsElement = document.querySelector('.js-teams');
+      const rangeToSelect = document.createRange();
+      const selection = window.getSelection();
+      selection.removeAllRanges();
+      rangeToSelect.selectNodeContents(teamsElement);
+      selection.addRange(rangeToSelect);
+      document.execCommand('copy');
+      selection.removeAllRanges();
     }
 }


### PR DESCRIPTION
# Pull Request

## Description
Add feature to copy generated teams list so it can be pasted into notepad.  In addition, team names can be edited instead of the default Team 1, 2, etc.  Team captain is also bolded now.

## PR Type
Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## Checklist
- [x] Tests added for the changes (for bug fixes / features)
- [x] Tests (`npm run test`) have all passed
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures
- [x] Commit messages format follows the [Angular Commit Guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)

## How to test the behavior?
### Setup

1. `git checkout copy`
1. `ng serve`

### Test Steps
- [x] Verify Copy button is not shown when there are no teams listed.
- [x] Enter player names and generate teams.
- [x] Verify Copy button is now shown.  Click on the Copy button
  - [x] Paste into Notes.  Verify the teams have been copied correctly.
- [x] Toggle "Show Team Captain".  Verify the team captain's name is bolded.
- [x] Click on the Team Name header.  The cell should now be editable to change the team name.
- [x] Click on the Copy button
  - [x] Paste into Notes.  Verify the teams along with edited team name have been copied correctly.
